### PR TITLE
Create Dockerfile for AudioBook-Maker backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# Dockerfile for AudioBook-Maker backend + engines
+# CPU focused, Python 3.10, Ubuntu based
+
+FROM python:3.10-slim AS base
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    # Force UTF-8 so logs look sane
+    PYTHONIOENCODING=utf-8
+
+# System deps: build tools, FFmpeg, git (for future extras)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ffmpeg \
+      build-essential \
+      git \
+      ca-certificates \
+      curl && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy only what the backend needs (you can extend this later)
+COPY backend/ backend/
+COPY database/ database/
+
+# Ensure setup scripts are executable
+RUN chmod +x backend/setup.sh \
+    && find backend/engines -name "setup.sh" -print -exec chmod +x {} \;
+
+# Create backend venv and install core dependencies
+# This uses the project's own setup script, which:
+#  - creates backend/venv
+#  - installs backend/requirements.txt
+RUN cd backend && ./setup.sh
+
+# Install engines inside the container using their own setup scripts.
+# You can comment out engines you do not want.
+RUN cd backend/engines/tts/xtts && ./setup.sh || echo "XTTS setup failed, continuing"
+RUN cd backend/engines/text_processing/spacy && ./setup.sh || echo "spacy setup failed, continuing"
+RUN cd backend/engines/audio_analysis/silero-vad && ./setup.sh || echo "Silero-VAD setup failed, continuing"
+RUN cd backend/engines/stt/whisper && ./setup.sh || echo "Whisper setup failed, continuing"
+RUN cd backend/engines/tts/chatterbox && ./setup.sh || echo "Chatterbox setup failed, continuing"
+
+# Create directories for persistent data
+#  - backend/media: audio files, speakers, etc.
+#  - database: SQLite DB
+RUN mkdir -p backend/media \
+    && mkdir -p /app/database
+
+# Expose FastAPI port (as in README)
+EXPOSE 8765
+
+# Default working dir and command
+WORKDIR /app/backend
+
+# Use the venv created by backend/setup.sh
+CMD ["venv/bin/python", "main.py"]


### PR DESCRIPTION
This Dockerfile sets up the AudioBook-Maker backend with Python 3.10 on an Ubuntu base, installs necessary dependencies, and configures the environment for various audio processing engines.

To build:
cd AudioBook-Maker

# Build the backend image
docker build -t audiobook-maker-backend .

This will:

Install Python dependencies listed in backend/requirements.txt Create engine specific venvs under backend/engines/.../venv Bake everything into a single image

From the repo root, run:
mkdir -p backend/media
mkdir -p database

Then run with:
docker run --rm \
  -p 8765:8765 \
  -v "$PWD/backend/media:/app/backend/media" \
  -v "$PWD/database:/app/database" \
  --name audiobook-maker-backend \
  audiobook-maker-backend

That gives you:

Backend FastAPI server listening on http://localhost:8765 inside the container, mapped to localhost:8765 on your host Persistent media and database on your host filesystem

Then:
docker run --rm \
  -p 8765:8765 \
  -v "$PWD/backend/media:/app/backend/media" \
  -v "$PWD/database:/app/database" \
  --name audiobook-maker-backend \
  audiobook-maker-backend

That gives you:

Backend FastAPI server listening on http://localhost:8765 inside the container, mapped to localhost:8765 on your host

Persistent media and database on your host filesystem

Use it with the existing Tauri desktop app

The current Quick Start has you run:

Backend: venv/bin/python main.py

Frontend: npm run dev:tauri in frontend 
GitHub

Once the container is running, you can skip the local backend venv and just:

Start the Docker container as above.

In another terminal, from project root:
cd frontend
npm install        # first time only
npm run dev:tauri

On first launch of the desktop app:

Click “Connect to Backend”

Use http://localhost:8765 as the backend URL (same as README)  GitHub

Configure your TTS engine in settings, upload speaker samples, etc.

From the app’s perspective there is no difference between a local backend and a Docker backend, since it already talks to the FastAPI service over HTTP.