### PR TITLE
Add pronunciation test audio preview

### DIFF
--- a/frontend/src/utils/translateBackendError.ts
+++ b/frontend/src/utils/translateBackendError.ts
@@ -233,7 +233,12 @@ export function translateBackendError(errorMessage: string, t: TFunction): strin
     PRONUNCIATION_BULK_OPERATION_FAILED: 'pronunciation.errors.bulkOperationFailed',
     PRONUNCIATION_RULES_EXPORT_FAILED: 'pronunciation.errors.exportFailed',
     PRONUNCIATION_RULES_IMPORT_FAILED: 'pronunciation.errors.importFailed',
+    PRONUNCIATION_TEST_ENGINE_NOT_SET: 'pronunciation.errors.testEngineNotSet',
+    PRONUNCIATION_TEST_SPEAKER_NOT_FOUND: 'pronunciation.errors.testSpeakerNotFound',
+    PRONUNCIATION_TEST_SAMPLE_MISSING: 'pronunciation.errors.testSampleMissing',
+    PRONUNCIATION_TEST_ENGINE_LOAD_FAILED: 'pronunciation.errors.testEngineLoadFailed',
     PRONUNCIATION_TEST_AUDIO_FAILED: 'pronunciation.errors.testAudioFailed',
+
 
     // Settings errors
     SETTINGS_KEY_NOT_FOUND: 'settings.errors.keyNotFound',


### PR DESCRIPTION
This PR adds a pronunciation test audio preview feature.

Changes included:

1. Updated backend endpoint `POST /api/pronunciation/rules/test-audio`
- Applies the test pronunciation rule to the segment text
- Uses the segment’s engine, model, language, and speaker to generate audio
- Writes a short preview file under `OUTPUT_DIR/previews`
- Returns `audio_path` pointing to the preview file

2. Updated frontend error translator
- Added mappings for new pronunciation test audio error codes

Only two files are modified:
- backend/api/pronunciation.py
- frontend/src/utils/translateBackendError.ts

This enables users to preview how a rule affects audio output before saving the rule.