### PR TITLE
One-click Book → Audiobook wizard

### DIFF
--- a/frontend/src/hooks/useFullBookWizard.ts
+++ b/frontend/src/hooks/useFullBookWizard.ts
@@ -1,0 +1,323 @@
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { projectApi, ttsApi } from '../services/api'
+import type { ImportExecuteResponse, MappingRules } from '../types'
+import { DEFAULT_MAPPING_RULES } from '../types'
+import { useAppStore } from '../store/appStore'
+import { useUISettingsStore } from '../store/uiSettingsStore'
+import { useTextEngineLanguages } from './useTextEngineLanguages'
+import { useDefaultSpeaker } from './useSpeakersQuery'
+import { useSnackbar } from './useSnackbar'
+import { logger } from '../utils/logger'
+import { translateBackendError } from '../utils/translateBackendError'
+
+export type FullBookWizardStatus =
+  | 'idle'
+  | 'importing'
+  | 'tts'
+  | 'done'
+  | 'error'
+
+export interface FullBookWizardState {
+  status: FullBookWizardStatus
+  message: string
+  isRunning: boolean
+  lastProjectId: string | null
+  lastProjectTitle: string | null
+  lastChapterCount: number
+}
+
+/**
+ * Small helper to detect EPUB files, mirroring useImportQuery logic.
+ */
+function isEpubFile(file: File): boolean {
+  const name = file.name.toLowerCase()
+  return name.endsWith('.epub')
+}
+
+/**
+ * One-click "Book → Audiobook" wizard:
+ *
+ * 1. Imports the book (Markdown or EPUB) as a new project.
+ * 2. Applies DEFAULT_MAPPING_RULES for chapter detection.
+ * 3. Uses the current default TTS engine / model / language / speaker.
+ * 4. Starts TTS generation for every chapter in the new project.
+ *
+ * Export still uses the existing export workflow (Export view).
+ */
+export function useFullBookWizard() {
+  const { t } = useTranslation()
+  const { showSnackbar } = useSnackbar()
+
+
+  const [state, setState] = useState<FullBookWizardState>({
+    status: 'idle',
+    message: '',
+    isRunning: false,
+    lastProjectId: null,
+    lastProjectTitle: null,
+    lastChapterCount: 0,
+  })
+
+  // Global TTS defaults from app store
+  const getDefaultTtsEngine = useAppStore(
+    (s) => s.getDefaultTtsEngine,
+  )
+  const getDefaultTtsModel = useAppStore(
+    (s) => s.getDefaultTtsModel,
+  )
+  const getDefaultLanguage = useAppStore(
+    (s) => s.getDefaultLanguage,
+  )
+
+  // UI / text language for import
+  const uiLanguage = useUISettingsStore((s) => s.settings.uiLanguage)
+  const { languages: textLanguages } = useTextEngineLanguages()
+
+  // Default speaker
+  const { data: defaultSpeaker } = useDefaultSpeaker()
+
+  const resetState = useCallback(() => {
+    setState({
+      status: 'idle',
+      message: '',
+      isRunning: false,
+      lastProjectId: null,
+      lastProjectTitle: null,
+      lastChapterCount: 0,
+    })
+  }, [])
+
+  const runWizard = useCallback(
+    async (file: File): Promise<ImportExecuteResponse> => {
+      if (!file) {
+        const msg = t('import.actions.noFileSelected', 'No file selected')
+        showSnackbar(msg, { severity: 'error' })
+        throw new Error(msg)
+      }
+
+      resetState()
+
+      setState((prev) => ({
+        ...prev,
+        status: 'importing',
+        isRunning: true,
+        message:
+          t('wizard.importingBook', 'Importing book and creating project...'),
+      }))
+
+      try {
+        // 1) Import: mapping rules and language
+        const mappingRules: MappingRules = DEFAULT_MAPPING_RULES
+
+        let textLanguage = uiLanguage || 'en'
+        if (textLanguages && textLanguages.length > 0) {
+          if (uiLanguage && textLanguages.includes(uiLanguage)) {
+            textLanguage = uiLanguage
+          } else {
+            textLanguage = textLanguages[0]
+          }
+        }
+
+        // 2) TTS defaults (engine / model / language / speaker)
+        const defaultEngine = getDefaultTtsEngine()
+        const ttsEngine = defaultEngine || ''
+        const ttsModelName =
+          (ttsEngine && getDefaultTtsModel(ttsEngine)) || ''
+        const ttsLanguage =
+          (ttsEngine && getDefaultLanguage(ttsEngine)) ||
+          textLanguage ||
+          'en'
+        const ttsSpeakerName = defaultSpeaker?.name ?? ''
+
+        const mode: 'new' = 'new'
+        const mergeTargetId: string | null = null
+        const selectedChapters: string[] = []
+        const renamedChapters: Record<string, string> = {}
+
+        // 3) Execute import directly (no preview step, "new" mode imports all chapters)
+        const importPromise = isEpubFile(file)
+          ? projectApi.executeEpubImport(
+              file,
+              mappingRules,
+              textLanguage,
+              mode,
+              mergeTargetId,
+              selectedChapters,
+              renamedChapters,
+              {
+                ttsEngine,
+                ttsModelName,
+                ttsLanguage,
+                ttsSpeakerName,
+              },
+            )
+          : projectApi.executeMarkdownImport(
+              file,
+              mappingRules,
+              textLanguage,
+              mode,
+              mergeTargetId,
+              selectedChapters,
+              renamedChapters,
+              {
+                ttsEngine,
+                ttsModelName,
+                ttsLanguage,
+                ttsSpeakerName,
+              },
+            )
+
+        const importResult = (await importPromise) as ImportExecuteResponse
+
+        const project = importResult.project
+        const chapters = project.chapters || []
+        const chapterCount = chapters.length
+
+        setState((prev) => ({
+          ...prev,
+          lastProjectId: importResult.projectId,
+          lastProjectTitle: project.title,
+          lastChapterCount: chapterCount,
+        }))
+
+        if (chapterCount === 0) {
+          const msg =
+            t(
+              'wizard.importedNoChapters',
+              'Import completed but no chapters were created.',
+            ) ||
+            'Import completed but no chapters were created.'
+          setState((prev) => ({
+            ...prev,
+            status: 'done',
+            isRunning: false,
+            message: msg,
+          }))
+          showSnackbar(msg, { severity: 'warning' })
+          return importResult
+        }
+
+        // 4) Kick off TTS for every chapter
+        setState((prev) => ({
+          ...prev,
+          status: 'tts',
+          message:
+            t(
+              'wizard.generatingTts',
+              'Starting text-to-speech jobs for all chapters...',
+            ) ||
+            'Starting text-to-speech jobs for all chapters...',
+        }))
+
+        for (let index = 0; index < chapters.length; index += 1) {
+          const chapter = chapters[index]
+          const displayIndex = index + 1
+
+          const stepMsg =
+            t('wizard.generatingChapter', {
+              index: displayIndex,
+              total: chapterCount,
+              title: chapter.title,
+            }) ||
+            `Generating audio for chapter ${displayIndex}/${chapterCount}: ${chapter.title}`
+
+          setState((prev) => ({
+            ...prev,
+            status: 'tts',
+            message: stepMsg,
+          }))
+
+          try {
+            await ttsApi.generateChapter({
+              chapterId: chapter.id,
+              forceRegenerate: false,
+              overrideSegmentSettings: false,
+            })
+          } catch (err) {
+            logger.error('Failed to start TTS for chapter', {
+              error: err,
+              chapterId: chapter.id,
+            })
+
+            // Non-fatal: keep going for other chapters, but show a warning
+            const warnMsg =
+              t('wizard.chapterTtsFailed', {
+                defaultValue:
+                  'Failed to start TTS for chapter "{{title}}". See logs for details.',
+                title: chapter.title,
+              }) ||
+              `Failed to start TTS for chapter "${chapter.title}". See logs for details.`
+            showSnackbar(warnMsg, { severity: 'warning' })
+          }
+        }
+
+        const finalMsg =
+          t(
+            'wizard.completed',
+            'Book imported and TTS jobs started for all chapters. You can monitor progress in the Jobs view and export audio when ready.',
+          ) ||
+          'Book imported and TTS jobs started for all chapters. You can monitor progress in the Jobs view and export audio when ready.'
+
+        setState((prev) => ({
+          ...prev,
+          status: 'done',
+          isRunning: false,
+          message: finalMsg,
+        }))
+
+        showSnackbar(finalMsg, { severity: 'success' })
+
+        return importResult
+      } catch (error: any) {
+        logger.error('Full-book wizard failed', { error })
+
+        let friendlyMessage =
+          t(
+            'wizard.unknownError',
+            'An error occurred while running the Book → Audiobook wizard.',
+          ) ||
+          'An error occurred while running the Book → Audiobook wizard.'
+
+        if (error?.response?.data?.detail) {
+          try {
+            friendlyMessage = translateBackendError(
+              error.response.data.detail,
+              t,
+            )
+          } catch {
+            // Fall back to generic message
+          }
+        } else if (error instanceof Error && error.message) {
+          friendlyMessage = error.message
+        }
+
+        setState((prev) => ({
+          ...prev,
+          status: 'error',
+          isRunning: false,
+          message: friendlyMessage,
+        }))
+
+        showSnackbar(friendlyMessage, { severity: 'error' })
+        throw error
+      }
+  }, [
+    t,
+    showSnackbar,
+    uiLanguage,
+    textLanguages,
+    defaultSpeaker,
+    getDefaultTtsEngine,
+    getDefaultTtsModel,
+    getDefaultLanguage,
+    resetState,
+  ],
+)
+  return {
+    ...state,
+    runWizard,
+    resetWizard: resetState,
+  }
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1109,6 +1109,9 @@
     "actions": {
       "import": "Importieren",
       "importing": "Importiere...",
+      "wizard": "Importieren + Hörbuch erzeugen",
+      "wizardRunning": "Assistent läuft...", 
+      "wizardRequiresNew": "Der Assistent unterstützt nur „Neues Projekt“. Modus wurde auf „Neu“ umgestellt.",
       "error": "Import fehlgeschlagen",
       "success": "Import abgeschlossen ({{chapters}} Kapitel, {{segments}} Segmente)",
       "invalidConfig": "Bitte füllen Sie alle erforderlichen Felder aus, bevor Sie importieren",
@@ -1385,5 +1388,14 @@
       "missingTargetId": "Zielprojekt-ID erforderlich für Merge-Modus",
       "unknownEngine": "Unbekannte TTS-Engine: {{engine}}"
     }
+  },
+  "wizard": {
+    "importingBook": "Buch wird importiert und Projekt wird erstellt...",
+    "importedNoChapters": "Import abgeschlossen, aber es wurden keine Kapitel erstellt.",
+    "generatingTts": "Text-zu-Sprache-Jobs für alle Kapitel werden gestartet...",
+    "generatingChapter": "Audio wird für Kapitel {{index}}/{{total}} erzeugt: {{title}}",
+    "chapterTtsFailed": "TTS konnte für das Kapitel \"{{title}}\" nicht gestartet werden. Siehe Logs für Details.",
+    "completed": "Buch importiert und TTS-Jobs für alle Kapitel gestartet. Fortschritt im Jobs-Bereich prüfen und exportieren, wenn alles fertig ist.",
+    "unknownError": "Beim Ausführen des Buch → Hörbuch-Assistenten ist ein Fehler aufgetreten."
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1109,12 +1109,15 @@
     "actions": {
       "import": "Import",
       "importing": "Importing...",
+      "wizard": "Import + Generate Audiobook",
+      "wizardRunning": "Running wizard...",
       "error": "Import failed",
       "success": "Import complete ({{chapters}} chapters, {{segments}} segments)",
       "invalidConfig": "Please complete all required fields before importing",
       "noFileSelected": "Please select a file to import",
       "noMergeTarget": "Please select a project to merge into",
-      "noChaptersSelected": "Please select at least one chapter to import"
+      "noChaptersSelected": "Please select at least one chapter to import",
+      "wizardRequiresNew": "Wizard supports only Create New Project. Switched mode to New Project."
     },
     "preview": {
       "emptyTitle": "No Preview Available",
@@ -1385,5 +1388,14 @@
       "missingTargetId": "Target project ID is required for merge mode",
       "unknownEngine": "Unknown TTS engine: {{engine}}"
     }
+  },
+  "wizard": {
+    "importingBook": "Importing book and creating project...",
+    "importedNoChapters": "Import completed but no chapters were created.",
+    "generatingTts": "Starting text-to-speech jobs for all chapters...",
+    "generatingChapter": "Generating audio for chapter {{index}}/{{total}}: {{title}}",
+    "chapterTtsFailed": "Failed to start TTS for chapter \"{{title}}\". See logs for details.",
+    "completed": "Book imported and TTS jobs started for all chapters. You can monitor progress in the Jobs view and export audio when ready.",
+    "unknownError": "An error occurred while running the Book → Audiobook wizard."
   }
 }

--- a/frontend/src/pages/FullBookWizardView.tsx
+++ b/frontend/src/pages/FullBookWizardView.tsx
@@ -1,0 +1,239 @@
+import React, { useState, useMemo } from 'react'
+import {
+  Box,
+  Paper,
+  Typography,
+  Stack,
+  Button,
+  LinearProgress,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  TextField,
+} from '@mui/material'
+import { Upload as UploadIcon, PlayArrow as PlayIcon } from '@mui/icons-material'
+import { useTranslation } from 'react-i18next'
+import { useFullBookWizard, type FullBookWizardOptions } from '@hooks/useFullBookWizard'
+import { defaultMappingRules } from '@types' // adjust import to where you define defaults
+
+export function FullBookWizardView() {
+  const { t } = useTranslation()
+  const [file, setFile] = useState<File | null>(null)
+  const [language, setLanguage] = useState('en')
+  const [outputFormat, setOutputFormat] =
+    useState<FullBookWizardOptions['exportFormat']>('mp3')
+  const [outputQuality, setOutputQuality] =
+    useState<FullBookWizardOptions['exportQuality']>('high')
+
+  // For now: force "new" projects, you can extend later
+  const mode: FullBookWizardOptions['mode'] = 'new'
+
+  const {
+    step,
+    progressText,
+    error,
+    result,
+    startWizard,
+    isRunning,
+    reset,
+  } = useFullBookWizard()
+
+  const canStart = useMemo(() => {
+    return !!file && !isRunning
+  }, [file, isRunning])
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = event.target.files?.[0]
+    if (selected) {
+      setFile(selected)
+    }
+  }
+
+  const handleStart = async () => {
+    if (!file) {
+      return
+    }
+
+    const options: FullBookWizardOptions = {
+      mappingRules: defaultMappingRules, // use your existing defaults
+      language,
+      mode,
+      mergeTargetId: null,
+      selectedChapters: [], // all chapters
+      renamedChapters: {},
+      ttsSettings: {
+        ttsEngine: 'local',        // or pull defaults from settings
+        ttsModelName: 'default',   // adjust to real default
+        language,
+      },
+      exportFormat: outputFormat,
+      exportQuality: outputQuality,
+    }
+
+    try {
+      await startWizard(file, options)
+    } catch {
+      // error state is already handled in hook
+    }
+  }
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" gutterBottom>
+        {t('wizard.fullBook.title', 'Book → Audiobook Wizard')}
+      </Typography>
+
+      <Typography variant="body1" color="text.secondary" gutterBottom>
+        {t(
+          'wizard.fullBook.description',
+          'Upload a structured Markdown or EPUB, pick your settings, and let the wizard import, generate TTS, and start exports for all chapters.'
+        )}
+      </Typography>
+
+      <Paper sx={{ p: 3, mt: 2 }}>
+        <Stack spacing={3}>
+          {/* File upload */}
+          <Box>
+            <Button
+              variant="outlined"
+              component="label"
+              startIcon={<UploadIcon />}
+            >
+              {file
+                ? t('wizard.fullBook.changeFile', 'Change file')
+                : t('wizard.fullBook.selectFile', 'Select book file')}
+              <input
+                type="file"
+                hidden
+                accept=".md,.markdown,.epub"
+                onChange={handleFileChange}
+              />
+            </Button>
+            {file && (
+              <Typography variant="body2" sx={{ mt: 1 }}>
+                {t('wizard.fullBook.selectedFile', 'Selected file')}: {file.name}
+              </Typography>
+            )}
+          </Box>
+
+          {/* Basic settings */}
+          <Stack direction="row" spacing={2}>
+            <TextField
+              label={t('wizard.fullBook.language', 'Language')}
+              value={language}
+              onChange={(e) => setLanguage(e.target.value)}
+              size="small"
+            />
+
+            <FormControl size="small">
+              <InputLabel id="wizard-output-format-label">
+                {t('wizard.fullBook.outputFormat', 'Output format')}
+              </InputLabel>
+              <Select
+                labelId="wizard-output-format-label"
+                label={t('wizard.fullBook.outputFormat', 'Output format')}
+                value={outputFormat}
+                onChange={(e) =>
+                  setOutputFormat(e.target.value as FullBookWizardOptions['exportFormat'])
+                }
+              >
+                <MenuItem value="mp3">MP3</MenuItem>
+                <MenuItem value="m4a">M4A</MenuItem>
+                <MenuItem value="wav">WAV</MenuItem>
+              </Select>
+            </FormControl>
+
+            <FormControl size="small">
+              <InputLabel id="wizard-output-quality-label">
+                {t('wizard.fullBook.outputQuality', 'Quality')}
+              </InputLabel>
+              <Select
+                labelId="wizard-output-quality-label"
+                label={t('wizard.fullBook.outputQuality', 'Quality')}
+                value={outputQuality}
+                onChange={(e) =>
+                  setOutputQuality(
+                    e.target.value as FullBookWizardOptions['exportQuality']
+                  )
+                }
+              >
+                <MenuItem value="low">{t('wizard.quality.low', 'Low')}</MenuItem>
+                <MenuItem value="medium">
+                  {t('wizard.quality.medium', 'Medium')}
+                </MenuItem>
+                <MenuItem value="high">
+                  {t('wizard.quality.high', 'High')}
+                </MenuItem>
+              </Select>
+            </FormControl>
+          </Stack>
+
+          {/* Start button */}
+          <Stack direction="row" spacing={2} alignItems="center">
+            <Button
+              variant="contained"
+              startIcon={<PlayIcon />}
+              onClick={handleStart}
+              disabled={!canStart}
+            >
+              {t('wizard.fullBook.start', 'Start full book wizard')}
+            </Button>
+
+            {isRunning && (
+              <Typography variant="body2" color="text.secondary">
+                {t('wizard.fullBook.running', 'Wizard is running...')}
+              </Typography>
+            )}
+
+            {step === 'done' && result && (
+              <Typography variant="body2" color="success.main">
+                {t(
+                  'wizard.fullBook.done',
+                  'Done. TTS and export jobs were started for {{count}} chapters.',
+                  { count: result.chapterIds.length }
+                )}
+              </Typography>
+            )}
+
+            {step === 'error' && error && (
+              <Typography variant="body2" color="error">
+                {t('wizard.fullBook.error', 'Wizard failed')}: {error}
+              </Typography>
+            )}
+          </Stack>
+
+          {/* Progress bar and text */}
+          {isRunning && (
+            <Box>
+              <LinearProgress />
+              <Typography variant="body2" sx={{ mt: 1 }}>
+                {progressText}
+              </Typography>
+            </Box>
+          )}
+
+          {/* Debug summary */}
+          {result && (
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="subtitle1">
+                {t('wizard.fullBook.summary', 'Summary')}
+              </Typography>
+              <Typography variant="body2">
+                Project: {result.projectId}
+              </Typography>
+              <Typography variant="body2">
+                Chapters: {result.chapterIds.length}
+              </Typography>
+              <Typography variant="body2">
+                Export jobs: {result.exportJobs.length}
+              </Typography>
+            </Box>
+          )}
+        </Stack>
+      </Paper>
+    </Box>
+  )
+}
+
+export default FullBookWizardView

--- a/frontend/src/utils/translateBackendError.ts
+++ b/frontend/src/utils/translateBackendError.ts
@@ -233,7 +233,12 @@ export function translateBackendError(errorMessage: string, t: TFunction): strin
     PRONUNCIATION_BULK_OPERATION_FAILED: 'pronunciation.errors.bulkOperationFailed',
     PRONUNCIATION_RULES_EXPORT_FAILED: 'pronunciation.errors.exportFailed',
     PRONUNCIATION_RULES_IMPORT_FAILED: 'pronunciation.errors.importFailed',
+    PRONUNCIATION_TEST_ENGINE_NOT_SET: 'pronunciation.errors.testEngineNotSet',
+    PRONUNCIATION_TEST_SPEAKER_NOT_FOUND: 'pronunciation.errors.testSpeakerNotFound',
+    PRONUNCIATION_TEST_SAMPLE_MISSING: 'pronunciation.errors.testSampleMissing',
+    PRONUNCIATION_TEST_ENGINE_LOAD_FAILED: 'pronunciation.errors.testEngineLoadFailed',
     PRONUNCIATION_TEST_AUDIO_FAILED: 'pronunciation.errors.testAudioFailed',
+
 
     // Settings errors
     SETTINGS_KEY_NOT_FOUND: 'settings.errors.keyNotFound',


### PR DESCRIPTION
This PR adds a one-click “Book → Audiobook” wizard that:

- Imports a Markdown or EPUB book as a new project
- Applies default chapter mapping rules
- Uses current default TTS engine/model/language/speaker
- Automatically starts TTS generation for all chapters

UI integration:
- New wizard button alongside Import
- Automatically switches to “New Project” mode if needed
- Navigates to Jobs view after successful start

Includes:
- useFullBookWizard hook
- ImportView integration
- Optional FullBookWizardView
- EN/DE i18n support

This builds on the existing import + TTS pipeline without changing backend behavior. And is my first large contribution, so there are bound to be issues. Please check everything twice. I had issues with the scoping and strings in German.
